### PR TITLE
Use HTTPS for URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Iconify is designed to be as easy to use as possible.
 Add this line to your page to load Iconify:
 
 ```
-<script src="//code.iconify.design/1/1.0.0-rc5/iconify.min.js"></script>
+<script src="https://code.iconify.design/1/1.0.0-rc5/iconify.min.js"></script>
 ```
     
 you can add it to ```<head>``` section of page or before ```</body>```. 

--- a/src/browser/defaults.js
+++ b/src/browser/defaults.js
@@ -56,7 +56,7 @@
     config._readyEvent = 'IconifyReady';
 
     // Polyfill URLs
-    config._webComponentsPolyfill = '//cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.24/webcomponents-lite.min.js';
-    config._classListPolyfill = '//cdnjs.cloudflare.com/ajax/libs/classlist/1.1.20150312/classList.min.js';
+    config._webComponentsPolyfill = 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.24/webcomponents-lite.min.js';
+    config._classListPolyfill = 'https://cdnjs.cloudflare.com/ajax/libs/classlist/1.1.20150312/classList.min.js';
 
 })(local.config);

--- a/src/browser/plugins/fa.js
+++ b/src/browser/plugins/fa.js
@@ -35,7 +35,7 @@
      *
      * @type {string}
      */
-    var stylesheetCDN = '//code.iconify.design/css/fa.css';
+    var stylesheetCDN = 'https://code.iconify.design/css/fa.css';
 
     /**
      * True if stylesheet has been added

--- a/src/browser/with-api/defaults.js
+++ b/src/browser/with-api/defaults.js
@@ -20,7 +20,7 @@
     "use strict";
 
     // API callback script
-    config.defaultAPI = '//api.iconify.design/{prefix}.js?icons={icons}';
+    config.defaultAPI = 'https://api.iconify.design/{prefix}.js?icons={icons}';
 
     // Custom API list. Key = prefix, value = API URL
     config.API = {};


### PR DESCRIPTION
This converts (hopefully) all instances of `//` to `https://`
All modified URLs have been checked to ensure they serve on HTTPS

The main benefit of this change is to allow Iconify to run on a local HTML page opened with a `file://` URL.

Currently, trying to do this results in errors such as the following
> Loading failed for the <script> with source “file:///mdi.js?icons=..."