### PR TITLE
Correctly set custom config (when using an IconifyConfig object)

### DIFF
--- a/src/browser/config.js
+++ b/src/browser/config.js
@@ -130,7 +130,7 @@
         if (global[prefix + 'Config'] !== void 0 && typeof global[prefix + 'Config'] === 'object') {
             obj = global[prefix + 'Config'];
             Object.keys(obj).forEach(function(key) {
-                setConfig(key, obj, true);
+                setConfig(key, obj[key], true);
             });
         }
     });


### PR DESCRIPTION
Use the value of the object instead of the whole object in the setConfig function for 'SimpleSVGConfig' and 'IconifyConfig'. This fixes a problem encountered in #4.